### PR TITLE
Allow setting an environment variable for CURRENT_ENGINE_NAME.

### DIFF
--- a/lib/engine_cart/tasks/engine_cart.rake
+++ b/lib/engine_cart/tasks/engine_cart.rake
@@ -59,7 +59,7 @@ EOF
 end
 
 def current_engine_name
-  File.basename(Dir.glob("*.gemspec").first, '.gemspec')
+  ENV["CURRENT_ENGINE_NAME"] || File.basename(Dir.glob("*.gemspec").first, '.gemspec')
 end
 
 def within_test_app


### PR DESCRIPTION
This enables blacklight to build with blacklight-bootstrap3 and
blacklight-bootstrap2 as the gem that gets included in Gemspec.
