### PR TITLE
Handling entry into .gitignore

### DIFF
--- a/lib/generators/engine_cart/install_generator.rb
+++ b/lib/generators/engine_cart/install_generator.rb
@@ -41,7 +41,7 @@ module EngineCart
       return if (system('git', 'check-ignore', TEST_APP, '-q') rescue false)
 
       append_file  File.expand_path('.gitignore', git_root) do 
-        "#{EngineCart.destination}\n"
+        "\n#{EngineCart.destination}\n"
       end 
     end
 


### PR DESCRIPTION
In cases where the last line of the .gitignore is a non-empty line,
this patch ensures that the injected entry isn't concatonated with the
non-empty line.
