### PR TITLE
Add preceeding whitespace to Gemfile

### DIFF
--- a/lib/generators/engine_cart/install_generator.rb
+++ b/lib/generators/engine_cart/install_generator.rb
@@ -48,6 +48,7 @@ module EngineCart
     def add_gemfile_include
       append_file "Gemfile" do
         <<-EOF
+
   file = File.expand_path("Gemfile", ENV['ENGINE_CART_DESTINATION'] || ENV['RAILS_ROOT'] || File.expand_path("../spec/internal", __FILE__))
   if File.exists?(file)
     puts "Loading \#{file} ..." if $DEBUG # `ruby -d` or `bundle -v`


### PR DESCRIPTION
In the case where the Gemfile did not have a trailing whitespace, the
first line was being appended to a `gem "rake"`
