### PR TITLE
Skipping spring for internal app generation

### DIFF
--- a/lib/engine_cart/tasks/engine_cart.rake
+++ b/lib/engine_cart/tasks/engine_cart.rake
@@ -30,7 +30,7 @@ namespace :engine_cart do
         end
 
         Bundler.with_clean_env do
-          `rails #{version} new internal #{EngineCart.rails_options} #{"-m #{EngineCart.template}" if EngineCart.template}`
+          `rails #{version} new internal --skip-spring #{EngineCart.rails_options} #{"-m #{EngineCart.template}" if EngineCart.template}`
         end
 
         unless $?


### PR DESCRIPTION
EngineCart was halting in spring-1.1.3/lib/spring/client/run.rb:54 as
Spring was attempting to start some semblance of a server.

Closes #15
http://stackoverflow.com/questions/23165506/rails-spring-breaking-generators
