### PR TITLE
Removing Rails dependency

### DIFF
--- a/engine_cart.gemspec
+++ b/engine_cart.gemspec
@@ -18,9 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rails"
+  spec.add_dependency "railties"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rails"
 end


### PR DESCRIPTION
By including Rails as a dependency, all sorts of extra things come
along.

By instead using Railties, this means we have a leaner dependency
chain. It also means that we are not always installing requiring
Rails for those leveraging EngineCart.

Why wouldn't a gem using EngineCart use all of Rails? For a similar
reason. Maybe the gem using EngineCart is only providing database
functionality and thus doesn't need Sprockets and ActionPack.