### PR TITLE
Extend the sqlite3 workaround to rails 5.2.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ rvm:
   - 2.5.3
 
 env:
- - "RAILS_VERSION=5.2.2"
+ - "RAILS_VERSION=5.2.2.1"

--- a/lib/engine_cart/tasks/engine_cart.rake
+++ b/lib/engine_cart/tasks/engine_cart.rake
@@ -48,7 +48,7 @@ namespace :engine_cart do
       Rake::Task['engine_cart:clean'].invoke if File.exist? EngineCart.destination
       FileUtils.move "#{dir}/internal", "#{EngineCart.destination}"
 
-      if Gem.loaded_specs['rails'].version.to_s <= '5.2.2'
+      if Gem.loaded_specs['rails'].version.to_s < '5.2.3'
         # Hack for https://github.com/rails/rails/issues/35153
         gemfile = File.join(EngineCart.destination, 'Gemfile')
         IO.write(gemfile, File.open(gemfile) do |f|


### PR DESCRIPTION
Unfortunately this may need to be bumped again when rails 5.2.3 gets released unless it includes the patch.