### PR TITLE
Ensures that Rails options are split by whitespace when generating Rails 6.y.z apps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,12 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rails', ENV['RAILS_VERSION'] if ENV['RAILS_VERSION']
+
+case ENV['RAILS_VERSION']
+when /^6\./
+  # This will only be necessary until release 6.0.1 is published (please see 
+  # https://github.com/rails/rails/issues/36954#issuecomment-522171807)
+  gem 'sass-rails', '~> 6.0'
+when /^5\./
+  gem 'sprockets', '~> 3.7'
+end

--- a/lib/engine_cart/configuration.rb
+++ b/lib/engine_cart/configuration.rb
@@ -51,7 +51,11 @@ module EngineCart
     ##
     # Additional options when generating a test rails application
     def rails_options
-      Array(options[:rails_options])
+      rails_options_values = options.fetch(:rails_options)
+      return [] if rails_options_values.nil?
+
+      rails_options = parse_options(rails_options_values)
+      Array(rails_options)
     end
 
     def extra_fingerprinted_files

--- a/spec/integration/engine_cart_spec.rb
+++ b/spec/integration/engine_cart_spec.rb
@@ -31,6 +31,29 @@ describe "EngineCart powered application" do
     end
   end
 
+  if ENV.fetch('RAILS_VERSION', 0).to_f >= 6.0
+    context "when JavaScript support is disabled" do
+      before do
+        FileUtils.mv(".engine_cart.yml", ".engine_cart.yml.disabled")
+        FileUtils.cp(".engine_cart.yml.disabled", ".engine_cart.yml")
+
+        config_file = open(".engine_cart.yml", "a")
+        config_file.write(" --skip-javascript")
+        config_file.close
+      end
+
+      after do
+        FileUtils.rm(".engine_cart.yml")
+        FileUtils.mv(".engine_cart.yml.disabled", ".engine_cart.yml")
+      end
+
+      it "should not insert webpacker tools" do
+        `bundle exec rake engine_cart:generate`
+        expect(File).not_to exist(".internal_test_app/bin/yarn")
+      end
+    end
+  end
+
   it "should not recreate an existing rails app when the engine_cart:generate task is reinvoked" do
     EngineCart.within_test_app do
       `bundle exec rake engine_cart:generate`


### PR DESCRIPTION
I apologize if this is not the proper approach to addressing this problem, please close this if it is not fit to be merged.

I was attempting to pass `--skip-javascript` within the `.engine_cart.yml` file in order to test a Gem against Rails 6.0.0 releases, and found that this was not being whitespace-separated with other Rails generator arguments. Also, I found that I needed to introduce several changes to ensure that the latest Travis CI builds pass for Rails 6.0.0 with sprockets 4.0.0 releases.