### PR TITLE
Ensuring rails_options are parsed

### DIFF
--- a/lib/engine_cart/configuration.rb
+++ b/lib/engine_cart/configuration.rb
@@ -78,7 +78,7 @@ module EngineCart
         destination: ENV['ENGINE_CART_DESTINATION'] || ENV['RAILS_ROOT'] || default_destination,
         template: ENV['ENGINE_CART_TEMPLATE'],
         templates_path: ENV['ENGINE_CART_TEMPLATES_PATH'] || './spec/test_app_templates',
-        rails_options: parse_options(ENV['ENGINE_CART_RAILS_OPTIONS']),
+        rails_options: Array(parse_options(ENV['ENGINE_CART_RAILS_OPTIONS'])),
         extra_fingerprinted_files: []
       }
     end
@@ -103,7 +103,13 @@ module EngineCart
     end
 
     def convert_keys(hash)
-      hash.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
+      hash.each_with_object({}) do |(k, v), h|
+        k_as_sym = k.to_sym
+        if k_as_sym == :rails_options
+          v = parse_options(v)
+        end
+        h[k_as_sym] = v
+      end
     end
 
     def default_configuration_paths

--- a/lib/engine_cart/tasks/engine_cart.rake
+++ b/lib/engine_cart/tasks/engine_cart.rake
@@ -34,9 +34,7 @@ namespace :engine_cart do
           require 'rails/generators'
           require 'rails/generators/rails/app/app_generator'
 
-          # Using the Rails generator directly, instead of shelling out, to
-          # ensure we use the right version of Rails.
-          Rails::Generators::AppGenerator.start([
+          generator_parameters = [
             'internal',
             '--skip-git',
             '--skip-keeps',
@@ -47,7 +45,13 @@ namespace :engine_cart do
             '--skip-test',
             *EngineCart.rails_options,
             ("-m #{EngineCart.template}" if EngineCart.template)
-          ].compact)
+          ].compact.uniq
+
+          puts "EngineCart generated Rails app '#{EngineCart.destination}' with the following parameters: #{generator_parameters.inspect}"
+
+          # Using the Rails generator directly, instead of shelling out, to
+          # ensure we use the right version of Rails.
+          Rails::Generators::AppGenerator.start(generator_parameters)
         end
         exit 0
       end


### PR DESCRIPTION
Prior to this commit, I had an `.engine_cart.yml` file with the
following YAML/ERB:

```yaml
<%
  rails_options = []
  rails_options << "--skip-listen" if ENV.fetch('RAILS_VERSION', '') < '5.0'
  rails_options << "--database=postgresql" if ENV.fetch('CI', false)
%>
rails_options: "<%= rails_options.join(' ') %>"
```

The rendered YAML was: `rails_options: "--skip-listen --database=postgresql"`

When I ran the `rake engine_cart:generate` the parameters passed to
`Rails::Generators::AppGenerator.start` were;

```ruby
[
  "internal",
  "--skip-git",
  "--skip-keeps",
  "--skip_spring",
  "--skip-bootsnap",
  "--skip-listen",
  "--skip-bundle",
  "--skip-test --database=postgresql"
]
```

Note, the last parameter, wihch cam from the `.engine_cart.yaml` are
not split. The end result is that the Rails generation did not build
the `.internal_test_app` with postgresql as the given database option.

In introducing this change, the above parameters were:

```ruby
[
  "internal",
  "--skip-git",
  "--skip-keeps",
  "--skip_spring",
  "--skip-bootsnap",
  "--skip-listen",
  "--skip-bundle",
  "--skip-test",
  "--database=postgresql"
]
```

With those parameters, the `.internal_test_app` was built with
postgresql as the default Rails database.

Also, to help any debugging, I'm adding an output to the generation
process to debug what configuration options I'm doing.

In this debugging, I disocvered that the `.engine_cart.yml` config
completely obliterates `ENGINE_CART_RAILS_OPTIONS` ENV. That is
acceptable but means some downstream implementations may not be
configuring their engine cart behavior as they thought, in particular
looking at [Hyrax's CircleCI Config][1] as it interplays with it's
[`.engine_cart.yml` configuration][2]

[1]:https://github.com/samvera/hyrax/blob/977e2d0719ba0d5163fc8719f86d0a094a8fb27e/.circleci/config.yml#L67
[2]:https://github.com/samvera/hyrax/blob/977e2d0719ba0d5163fc8719f86d0a094a8fb27e/.engine_cart.yml