### PR TITLE
Drop --skip-bundle from the default options because webpacker depends…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.6.3
+  - 2.7.1
 
 env:
- - "RAILS_VERSION=5.2.3"
- - "RAILS_VERSION=6.0.0"
+ - "RAILS_VERSION=5.2.4.3"
+ - "RAILS_VERSION=6.0.3.2"

--- a/lib/engine_cart/tasks/engine_cart.rake
+++ b/lib/engine_cart/tasks/engine_cart.rake
@@ -43,7 +43,6 @@ namespace :engine_cart do
             '--skip_spring',
             '--skip-bootsnap',
             '--skip-listen',
-            '--skip-bundle',
             '--skip-test',
             *EngineCart.rails_options,
             ("-m #{EngineCart.template}" if EngineCart.template)


### PR DESCRIPTION
… on bundle install having run..