### PR TITLE
Use thread over fork to support win32 platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ rvm:
   - 2.6.3
 
 env:
- - "RAILS_VERSION=5.2.3"
- - "RAILS_VERSION=6.0.0"
+ - "RAILS_VERSION=5.2.4.4"
+ - "RAILS_VERSION=6.0.3.4"


### PR DESCRIPTION
I'm really not sure if this is supporting the exact original use case. However, this aims to better support developers using win32 platforms where `fork` is not available. 🤷‍♂️ 

https://ruby-doc.org/core-2.7.2/Process.html#method-c-fork