### PR TITLE
Fix parsing of ENGINE_CART_RAILS_OPTIONS

### DIFF
--- a/lib/engine_cart/configuration.rb
+++ b/lib/engine_cart/configuration.rb
@@ -1,5 +1,6 @@
 require 'yaml'
 require 'erb'
+require 'shellwords'
 
 module EngineCart
   class Configuration
@@ -86,10 +87,11 @@ module EngineCart
     # Split a string of options into individual options.
     # @example
     #   parse_options('--skip-foo --skip-bar -d postgres --skip-lala')
-    #   # => ["--skip-foo", "--skip-bar", "-d postgres", "--skip-lala"]
+    #   # => ["--skip-foo", "--skip-bar", "-d", "postgres", "--skip-lala"]
     def parse_options(options)
       return if options.nil?
-      options.scan(/(--[^\s]+|-[^\s]+\s+[^\s]+)/).flatten
+
+      Shellwords.shellwords(options)
     end
 
     def read_config(config_file)


### PR DESCRIPTION
The Rails::Generator::AppGenerator expects the arguments similar to how they would come from ARGV. This means we only need to split on spaces, there is no need to group options and values.

See https://github.com/rails/rails/blob/f95c0b7e96eb36bc3efc0c5beffbb9e84ea664e4/railties/lib/rails/commands/application/application_command.rb#L26-L28

This was preventing blacklight from testing using "-a propshaft"