### PR TITLE
Apparently splitting these onto separate lines makes a difference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,10 @@ jobs:
         ruby:
           - 2.7
         rails_version:
-          - 5.2.7
-          - 6.0.4.7
-          - 6.1.5
+          - 5.2.8.1
+          - 6.0.5.1
+          - 6.1.6.1
+          - 7.0.3.1
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/Rakefile
+++ b/Rakefile
@@ -25,12 +25,17 @@ task :generate_test_gem => ['engine_cart:setup'] do
 
   system("mv #{Dir.pwd}/internal_test_gem #{Dir.pwd}/.internal_test_gem")
 
-  IO.write(".internal_test_gem/internal_test_gem.gemspec", File.open(".internal_test_gem/internal_test_gem.gemspec") {|f| f.read.gsub(/FIXME/, "DONTCARE")})
-  IO.write(".internal_test_gem/internal_test_gem.gemspec", File.open(".internal_test_gem/internal_test_gem.gemspec") {|f| f.read.gsub(/TODO/, "DONTCARE")})
-  IO.write(".internal_test_gem/internal_test_gem.gemspec", File.open(".internal_test_gem/internal_test_gem.gemspec") {|f| f.read.gsub(/.*homepage.*/, "")})
-  IO.write(".internal_test_gem/internal_test_gem.gemspec", File.open(".internal_test_gem/internal_test_gem.gemspec") {|f| f.read.gsub(/.*sqlite3.*/, "")})
-  IO.write(".internal_test_gem/internal_test_gem.gemspec", File.open(".internal_test_gem/internal_test_gem.gemspec") {|f| f.read.gsub(/.*source_code_uri.*/, "")})
-  IO.write(".internal_test_gem/internal_test_gem.gemspec", File.open(".internal_test_gem/internal_test_gem.gemspec") {|f| f.read.gsub(/.*changelog_uri.*/, "")})
+  gemspec_data = File.open(".internal_test_gem/internal_test_gem.gemspec") do |f|
+    f.read.gsub(/FIXME/, "DONTCARE")
+          .gsub(/TODO/, "DONTCARE")
+          .gsub(/.*homepage.*/, "")
+          .gsub(/.*sqlite3.*/, "")
+          .gsub(/.*source_code_uri.*/, "")
+          .gsub(/.*changelog_uri.*/, "")
+  end
+
+  IO.write(".internal_test_gem/internal_test_gem.gemspec", gemspec_data)
+  IO.write(".internal_test_gem/Gemfile", File.open(".internal_test_gem/Gemfile") {|f| f.read.gsub(/.*sqlite3.*/, "")})
 
   Rake::Task['engine_cart:inject_gemfile_extras'].invoke
   EngineCart.within_test_app do

--- a/lib/engine_cart/tasks/engine_cart.rake
+++ b/lib/engine_cart/tasks/engine_cart.rake
@@ -112,7 +112,8 @@ namespace :engine_cart do
       within_test_app do
         unless (system("bundle install --quiet") or system("bundle update --quiet")) and
               system "(bundle exec rails g | grep test_app) && bundle exec rails generate test_app" and
-              system "bundle exec rake db:migrate db:test:prepare"
+              system "bundle exec rake db:migrate" and
+              system "bundle exec rake db:test:prepare"
           raise "EngineCart failed on with: #{$?}"
         end
       end


### PR DESCRIPTION
> Calling db:migrate and db:test:prepare in separate invocations of rake allows them to be successful. I suspect db:migrate is leaving a db connection open and db:test:prepare is trying to drop the database which fails when there are open connections due to some change in rails 6. The easiest way to fix this is to patch engine_cart to call those tasks separately.