### PR TITLE
Drop deprecated versions of Rails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ jobs:
         ruby:
           - 2.7
         rails_version:
-          - 5.2.8.1
-          - 6.0.5.1
           - 6.1.6.1
           - 7.0.3.1
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -4,13 +4,3 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rails', ENV['RAILS_VERSION'] if ENV['RAILS_VERSION']
-
-case ENV['RAILS_VERSION']
-when /^6.0/
-  gem 'sass-rails', '>= 6'
-  gem 'webpacker', '~> 4.0'
-when /^5.[12]/
-  gem 'sprockets', '< 4.0'
-  gem 'sass-rails', '~> 5.0'
-  gem 'thor', '~> 0.20'
-end

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Rake tasks to generate a test application for a Rails Engine gem.
 If you have a Rails Engine and want to test it, the suggested approach is a small dummy application that loads up a Rails application with your engine loaded. This dummy application is usually checked into source control and maintained with the application. This works great, until you want to test:
 
  - different versions of Ruby (e.g. MRI and JRuby)
- - different versions of Rails (Rails 5.0, 6.0)
+ - different versions of Rails (Rails 6.1, 7.1)
  - different deployment environments (with and without devise, etc)
 
 where each scenario may involve different configurations, Gemfiles, etc.

--- a/engine_cart.gemspec
+++ b/engine_cart.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'rails', '>= 5.0'
+  spec.add_dependency 'rails', '>= 6.1'
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 end

--- a/lib/engine_cart/gemfile_stanza.rb
+++ b/lib/engine_cart/gemfile_stanza.rb
@@ -1,6 +1,6 @@
 module EngineCart
   def self.gemfile_stanza_check_line
-    'engine_cart stanza: 2.5.0'
+    'engine_cart stanza: 2.6.0'
   end
 
   def self.gemfile_stanza_text
@@ -23,19 +23,9 @@ module EngineCart
       if ENV['RAILS_VERSION']
         if ENV['RAILS_VERSION'] == 'edge'
           gem 'rails', github: 'rails/rails'
-          ENV['ENGINE_CART_RAILS_OPTIONS'] = '--edge --skip-turbolinks'
+          ENV['ENGINE_CART_RAILS_OPTIONS'] = '--edge'
         else
           gem 'rails', ENV['RAILS_VERSION']
-        end
-
-        case ENV['RAILS_VERSION']
-        when /^6.0/
-          gem 'sass-rails', '>= 6'
-          gem 'webpacker', '~> 4.0'
-        when /^5.[12]/
-          gem 'sass-rails', '~> 5.0'
-          gem 'sprockets', '~> 3.7'
-          gem 'thor', '~> 0.20'
         end
       end
     end

--- a/lib/engine_cart/tasks/engine_cart.rake
+++ b/lib/engine_cart/tasks/engine_cart.rake
@@ -27,7 +27,6 @@ namespace :engine_cart do
   task :create_test_rails_app => [:setup] do
     require 'tmpdir'
     require 'fileutils'
-    require 'rails/version'
 
     Dir.mktmpdir do |dir|
       # Fork into a new process to avoid polluting the current one with the partial Rails environment ...
@@ -67,15 +66,6 @@ namespace :engine_cart do
 
       Rake::Task['engine_cart:clean'].invoke if File.exist? EngineCart.destination
       FileUtils.move "#{dir}/internal", "#{EngineCart.destination}"
-
-      if Rails.version < '5.2.3'
-        # Hack for https://github.com/rails/rails/issues/35153
-        gemfile = File.join(EngineCart.destination, 'Gemfile')
-        IO.write(gemfile, File.open(gemfile) do |f|
-          text = f.read
-          text.gsub(/^gem ["']sqlite3["']$/, 'gem "sqlite3", "~> 1.3.0"')
-        end)
-      end
 
       if RUBY_VERSION < '3.0'
         # Hack for https://github.com/cbeer/engine_cart/issues/125


### PR DESCRIPTION
See https://endoflife.date/rails

Ruby 5.2 does not work with Ruby 3 (see https://github.com/rails/rails/issues/40938)