### PR TITLE
Change the default tested ruby from 2.7 to 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,15 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.7
+          - 3.1
         rails_version:
-          - 5.2.8.1
-          - 6.0.5.1
           - 6.1.6.1
           - 7.0.3.1
+        include:
+          - ruby: '2.7.8' # Rails 6.0 will not run on Ruby 3
+            rails_version: '6.0.5.1'
+          - ruby: '2.7.8' # Rails 5.2 will not run on Ruby 3
+            rails_version: '5.2.8.1'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby


### PR DESCRIPTION
Ruby 2.7 is EOL and many gems such as SQLite 1.7+ don't install on it.