### PR TITLE
Remove the internal_gem Gemfile.lock before the test starts:

### DIFF
--- a/spec/integration/engine_cart_spec.rb
+++ b/spec/integration/engine_cart_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe "EngineCart powered application" do
+  before do
+    FileUtils.rm_rf("#{EngineCart.destination}/Gemfile.lock")
+  end
+
   it "should have the test_app_templates pre-generated" do
     expect(File).to exist File.expand_path("spec/test_app_templates", EngineCart.destination)
   end


### PR DESCRIPTION
- The test suite of this gem is broken since Bundler 2.5.0 with this ruby/rubygems#5700.

  TL;DR is that the Gemfile.lock from the internal_gem doesn't match its Gemfile which now causes problems.

  ----

  When the sqlite3 gem [gets stripped](https://github.com/cbeer/engine_cart/blob/b89464ce94b3c168c296e9ec893482b4ca673e74/Rakefile#L38) from the internal_gem Gemfile, the resulting Gemfile.lock (that gets created when running [bundle update](https://github.com/cbeer/engine_cart/blob/b89464ce94b3c168c296e9ec893482b4ca673e74/Rakefile#L64)), will not contain sqlite3 for any platforms.

  When your test starts and the "internal_app" gets generated, this condition inside the Gemfile https://github.com/cbeer/engine_cart/blob/b89464ce94b3c168c296e9ec893482b4ca673e74/lib/engine_cart/gemfile_stanza.rb#L12-L15 gets evaluated and Bundler tries to evaluates the Gemfile of the app.

  We are now in a situation where the Gemfile of the internal gem doesn't match at all what's in the Gemfile.lock (since at the time the Gemfile.lock was generated, the `eval_gemfile` didn't get evaluated since no internal_app existed).

  With the change introduced in #5700, the initial generation of the Gemfile.lock adds all linux platforms (this is in the case your Gemfile includes a gem that comes with precompiled binaries like nokogiri). Now, when the Gemfile.lock contains a PLATFORM section, it checks whether all gem in the Gemfile are locked for those specific platforms.